### PR TITLE
Enable a setter/getter for the sessions

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -50,6 +50,12 @@ class Options
      */
     protected $authType;
 
+    /**
+     * Init default session
+     * @var bool
+     */
+    protected $sessionManager = true;
+
     public function getHost()
     {
         if (!$this->host) {
@@ -211,6 +217,18 @@ class Options
     public function setAuthType(Authenticable $authType)
     {
         $this->authType = $authType;
+        return $this;
+    }
+
+    public function getSessionManager(): bool
+    {
+        return $this->sessionManager;
+    }
+
+    public function setSessionManager(bool $sessionManager)
+    {
+        $this->sessionManager = $sessionManager;
+
         return $this;
     }
 }

--- a/src/XmppClient.php
+++ b/src/XmppClient.php
@@ -35,7 +35,10 @@ class XmppClient
         $this->iq = new Iq($this->socket, $options);
         $this->presence = new Presence($this->socket, $options);
         $this->message = new Message($this->socket, $options);
-        $this->initSession($sessionId);
+
+        if ($this->options->getSessionManager() !== false) {
+            $this->initSession($sessionId);
+        }
     }
 
     public function connect()


### PR DESCRIPTION
The case here is when you try to implement the package within a framework _eg:laravel_, there will be a conflict between the main framework session manager and the session initializer in the package.

I had tried to implement this with the ability to implement more advanced options for the session -_if needed_- in the future, for example a session managers classes.

It's only have the option to enable/disable the current implementation for the built-in session manager/initializer.