### PR TITLE
prevent errors if fopen fails

### DIFF
--- a/src/Loggers/Logger.php
+++ b/src/Loggers/Logger.php
@@ -46,8 +46,10 @@ class Logger implements Loggable
 
     protected function writeToLog($message, $type = ''): void
     {
-        $prefix = date("Y.m.d H:i:s") . " " . session_id() . ($type ? " {$type}::" : " ");
-        $this->writeToFile($this->log, $prefix . "$message\n");
+        if ($this->log) {
+            $prefix = date("Y.m.d H:i:s") . " " . session_id() . ($type ? " {$type}::" : " ");
+            $this->writeToFile($this->log, $prefix . "$message\n");
+        }
     }
 
     protected function writeToFile($file, $message)


### PR DESCRIPTION
Writing to a fixed path in this manner creates problems in Laravel, i.e. the `/public` folder is not writable for security reasons.